### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 RomanNumbers
 ============
 [![Build Status](https://travis-ci.org/RedXBeard/RomanNumbers.svg?branch=master)](https://travis-ci.org/RedXBeard/RomanNumbers) 
-[![Downloads](https://pypip.in/download/RomanAlphabet/badge.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
-[![Latest Version](https://pypip.in/version/RomanAlphabet/badge.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
-[![Supported Python versions](https://pypip.in/py_versions/RomanAlphabet/badge.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
-[![License](https://pypip.in/license/RomanAlphabet/badge.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
+[![Downloads](https://img.shields.io/pypi/dm/RomanAlphabet.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
+[![Latest Version](https://img.shields.io/pypi/v/RomanAlphabet.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/RomanAlphabet.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
+[![License](https://img.shields.io/pypi/l/RomanAlphabet.svg)](https://pypi.python.org/pypi/RomanAlphabet/)
 
 Roman or Integer numbers can be converted into eachother an additionally representation of each one of them into binary
 format.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20romanalphabet))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `romanalphabet`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.